### PR TITLE
Elastic mod

### DIFF
--- a/builder/main.go
+++ b/builder/main.go
@@ -52,6 +52,10 @@ func main() {
 	donOtamsi := NewDoNotAmsiModule()
 	builder.RegisterModule(donOtamsi)
 
+	// Register the 'elastic' module
+	elasticModule := NewElasticModule()
+	builder.RegisterModule(elasticModule)
+
 	// Register new modules here
 	// ...
 

--- a/builder/mod-elastic.go
+++ b/builder/mod-elastic.go
@@ -31,6 +31,7 @@ func NewElasticModule() *ElasticModule {
 			{search: "RegistryReadReq", replace: "Roberto"},
 			{search: "RequestResend", replace: "Frankie"},
 			{search: "GetPrivInfo", replace: "Wallace"},
+			{search: "-NoExit", replace: "-nOExIt"},
 		},
 	}
 }

--- a/builder/mod-elastic.go
+++ b/builder/mod-elastic.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"cloak/pkg/subs"
+	"fmt"
+	"path/filepath"
+)
+
+
+type ElasticModule struct {
+	ignoreList   []string
+	renamePaths  bool
+	replacePairs []SearchReplacePair
+}
+
+func NewElasticModule() *ElasticModule {
+	return &ElasticModule{
+		ignoreList:  []string{".git", ".github", "docs", "vendor"},
+		renamePaths: true,
+		replacePairs: []SearchReplacePair{
+			{search: "IfconfigReq", replace: "Frank"},
+			{search: "ImpersonateReq", replace: "Steve"},
+			{search: "InvokeMigrateReq", replace: "Paul"},
+			{search: "RevToSelfReq", replace: "Gerald"},
+			{search: "ScreenshotReq", replace: "Smith"},
+			{search: "SideloadReq", replace: "Alex"},
+			{search: "InvokeSpawnDllReq", replace: "Derek"},
+			{search: "NetstatReq", replace: "Grant"},
+			{search: "httpSessionInit", replace: "Robert"},
+			{search: "screenshotRequested", replace: "Wayne"},
+			{search: "RegistryReadReq", replace: "Roberto"},
+			{search: "RequestResend", replace: "Frankie"},
+			{search: "GetPrivInfo", replace: "Wallace"},
+		},
+	}
+}
+
+func (m *ElasticModule) Name() string {
+	return "Elastic"
+}
+
+func (m *ElasticModule) Run(config *Config, verbose bool) error {
+	startPath := filepath.Join(config.RunDir, "sliver")
+
+	// Start the recursive search and replace
+	var err error
+	for _, pair := range m.replacePairs {
+
+		err = subs.SearchAndReplace(startPath, pair.search, pair.replace, m.ignoreList, verbose)
+		if err != nil {
+			return fmt.Errorf("[Elastic] [SearchAndReplace] error during execution: %v", err)
+		}
+
+		err = subs.SearchAndRenameFiles(startPath, pair.search, pair.replace, m.ignoreList, verbose)
+		if err != nil {
+			return fmt.Errorf("[Elastic] [SearchAndRenameFiles] error during execution: %v", err)
+		}
+
+		err = subs.SearchAndRenameDirectories(startPath, pair.search, pair.replace, m.ignoreList, verbose)
+		if err != nil {
+			return fmt.Errorf("[Elastic] [SearchAndRenameDirectories] error during execution: %v", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
I have created an elastic mod that changes out some elastic string signature for some ransom words(names), I have also changed the wasy sliver does powershell slightly so that does not get triggered

The sigs i targeted were

https://github.com/elastic/protections-artifacts/blob/2d6189bff696a15279beef6df415da22aeeef7a6/behavior/rules/command_and_control_potential_execution_via_sliver_framework.toml#L22

https://github.com/elastic/protections-artifacts/blob/065efe897b511e9df5116f9f96b6cbabb68bf1e4/yara/rules/Multi_Trojan_Sliver.yar#L2

https://github.com/elastic/protections-artifacts/blob/065efe897b511e9df5116f9f96b6cbabb68bf1e4/yara/rules/Windows_Trojan_Sliver.yar#L2

There is only 1 rule that still procs and that is due to the protobuff string Multi_Trojan_Sliver_3bde542d - $a1 = "B/Z-github.com/bishopfox/sliver/protobuf/sliverpbb" ascii fullword

Like i mentioned in a message to you, this needs to be bypassed when compiling the protobuff. As currently the "sliverpbb" is signatured. Perhaps the makefile can be edited to compile a random name for the PB each time it runs?
